### PR TITLE
add example for installing epel composer with php74

### DIFF
--- a/markdown/faq.md
+++ b/markdown/faq.md
@@ -118,7 +118,8 @@ This can happen if the package you want to install has dependencies that could
 be satisfied by multiple IUS packages.  Yum's dependency resolution is not
 always smart enough to pull in all the correct dependencies.  You can work
 around this by explicitly requesting a few more package names to help the
-transaction resolve successfully.  `yum deplist non-ius-package` shows dependencies including alternatives.
+transaction resolve successfully.  `yum deplist <package>` shows dependencies
+including alternatives.
 
 Alternatively, you can install [DNF][dnf], which has more sophisticated
 dependency resolution capabilities and can determine the right thing to do.
@@ -130,7 +131,7 @@ to help yum resolve the transaction.
 
 - `yum install composer php72u-{cli,common,gd,intl,mbstring,pdo,process}`
 - `yum install composer php73-{cli,common,gd,intl,mbstring,pdo,process}`
-- `yum install composer php74-{cli,common,gd,intl,mbstring,pdo,process,pecl-zip}`
+- `yum install composer php74-{gd,mbstring,pdo,process,pecl-zip}`
 
 Alternatively, you can use [DNF][dnf].  If you already have some PHP packages
 installed, it will resolve matching ones.  If you don't have any PHP packages

--- a/markdown/faq.md
+++ b/markdown/faq.md
@@ -130,6 +130,7 @@ to help yum resolve the transaction.
 
 - `yum install composer php72u-{cli,common,gd,intl,mbstring,pdo,process}`
 - `yum install composer php73-{cli,common,gd,intl,mbstring,pdo,process}`
+- `yum install composer php74-{cli,common,gd,intl,mbstring,pdo,process,pecl-zip}`
 
 Alternatively, you can use [DNF][dnf].  If you already have some PHP packages
 installed, it will resolve matching ones.  If you don't have any PHP packages

--- a/markdown/faq.md
+++ b/markdown/faq.md
@@ -118,7 +118,7 @@ This can happen if the package you want to install has dependencies that could
 be satisfied by multiple IUS packages.  Yum's dependency resolution is not
 always smart enough to pull in all the correct dependencies.  You can work
 around this by explicitly requesting a few more package names to help the
-transaction resolve successfully.
+transaction resolve successfully.  `yum deplist non-ius-package` shows dependencies including alternatives.
 
 Alternatively, you can install [DNF][dnf], which has more sophisticated
 dependency resolution capabilities and can determine the right thing to do.


### PR DESCRIPTION
I had some issues when updating from php73 to php74 with missing packages, and tried adding different packages to resolve `yum install epel` until it worked.

`php74-pecl-zip` seems to solve it.

Error log from composer.
[composer-error.txt](https://github.com/iusrepo/iusrepo.github.io/files/5076844/composer-error.txt)

output of `sudo yum deplist composer`
[composer-deplist.txt](https://github.com/iusrepo/iusrepo.github.io/files/5077026/composer-deplist.txt)

